### PR TITLE
Added Notes Screen

### DIFF
--- a/lib/screens/notes/notes_screen.dart
+++ b/lib/screens/notes/notes_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: const NotesPage(),
+      debugShowCheckedModeBanner: false,
+    );
+  }
+}
+class NotesPage extends StatelessWidget {
+  const NotesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          'Taskify',
+          style: TextStyle(
+            color: Colors.blueAccent,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        actions: const [
+          Padding(
+            padding: EdgeInsets.only(right: 16.0),
+            child: Icon(Icons.menu, color: Colors.black), // we will use the menu function here
+          )
+        ],
+      ),
+      backgroundColor: Colors.grey[100],
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              "My Notes",
+              style: TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton.icon(
+              onPressed: () {
+                //will implement in another PR
+              },
+              icon: const Icon(Icons.add),
+              label: const Text("New Note"),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.blue,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+              ),
+            ),
+            const SizedBox(height: 12),
+            TextField(
+              decoration: InputDecoration(
+                hintText: "Search notes...",
+                prefixIcon: const Icon(Icons.search),
+                border: OutlineInputBorder(borderRadius: BorderRadius.circular(10)),
+                contentPadding: const EdgeInsets.symmetric(vertical: 0, horizontal: 12),
+              ),
+            ),
+            const SizedBox(height: 16),
+
+            // Notes will be fetched from backend here
+            const Expanded(
+              child: Center(
+                child: Text(
+                    'No notes yet'
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This PR adds the frontend layout for the Notes screen in the Taskify app. It includes:
- Navbar (not responsive)
- Page heading ("My Notes")
- "+ New Note" button
- Search bar 

![Screenshot 2025-06-20 135757](https://github.com/user-attachments/assets/368a4ef3-57a0-4445-89df-043fb318a7dc)

Requesting Review: @divyansh1705 
Closes #19 
